### PR TITLE
Added check for json_decode result

### DIFF
--- a/src/Message/GetUserDomainsResponse.php
+++ b/src/Message/GetUserDomainsResponse.php
@@ -58,6 +58,11 @@ class GetUserDomainsResponse extends AbstractResponse
     {
         if ($this->isSuccessful()) {
             $data = json_decode($this->getData(), true);
+            
+            if($data == null){
+                //throw new \RuntimeException('Failed to decode JSON data: ' . $this->getData());
+                return null;
+            }
 
             $statuses = array_unique(array_map(function ($item) {
                 return $item[0];

--- a/src/Message/GetUserDomainsResponse.php
+++ b/src/Message/GetUserDomainsResponse.php
@@ -59,8 +59,7 @@ class GetUserDomainsResponse extends AbstractResponse
         if ($this->isSuccessful()) {
             $data = json_decode($this->getData(), true);
             
-            if($data == null){
-                //throw new \RuntimeException('Failed to decode JSON data: ' . $this->getData());
+            if ($data == null) {
                 return null;
             }
 

--- a/tests/Message/GetUserDomainsRequestTest.php
+++ b/tests/Message/GetUserDomainsRequestTest.php
@@ -25,6 +25,17 @@ class GetUserDomainsRequestTest extends RequestTestCase
         $this->request->initialize($this->requestData);
     }
 
+    public function testNullServerResponse(){
+        // Ensure $response->getStatus() returned `null` if the server responded with "null"
+        $this->mockHandler->append(new Response(200, [], 'null'));
+
+        $response = $this->request->send();
+        $this->assertInstanceOf(GetUserDomainsResponse::class, $response);
+        $this->assertEquals(null, $response->getStatus());
+
+        $this->assertValidGetCall('getuserdomains');
+    }
+
     public function testGetData()
     {
         $data = $this->request->getData();


### PR DESCRIPTION
Fix #39 

Checked `json_decode` result if it's null, then return a `null`.

On line 63, I've added `throw new \RuntimeException('Failed to decode JSON data: ' . $this->getData());` which can be uncommented if you prefer Exception to be thrown instead of returning `null`.