### PR TITLE
improved phpdoc

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -184,7 +184,7 @@ class Client
      * - plan: The hosting plan to create the acccount on
      *
      * @param array $parameters
-     * @return AbstractRequest
+     * @return CreateAccountRequest
      */
     public function createAccount(array $parameters = array())
     {
@@ -199,7 +199,7 @@ class Client
      * - reason: The reason why the account was suspended
      *
      * @param array $parameters
-     * @return AbstractRequest
+     * @return SuspendRequest
      */
     public function suspend(array $parameters = array())
     {
@@ -213,7 +213,7 @@ class Client
      * - username: The custom username
      *
      * @param array $parameters
-     * @return AbstractRequest
+     * @return UnsuspendRequest
      */
     public function unsuspend(array $parameters = array())
     {
@@ -228,7 +228,7 @@ class Client
      * - password: The new password
      *
      * @param array $parameters
-     * @return AbstractRequest
+     * @return PasswordRequest
      */
     public function password(array $parameters = array())
     {
@@ -242,7 +242,7 @@ class Client
      * - domain: The domain name or subdomain to check
      *
      * @param array $parameters
-     * @return AbstractRequest
+     * @return AvailabilityRequest
      */
     public function availability(array $parameters = array())
     {
@@ -256,7 +256,7 @@ class Client
      * - username
      *
      * @param array $parameters
-     * @return AbstractRequest
+     * @return GetUserDomainsRequest
      */
     public function getUserDomains(array $parameters = array())
     {

--- a/src/Message/AvailabilityRequest.php
+++ b/src/Message/AvailabilityRequest.php
@@ -2,6 +2,9 @@
 
 namespace HansAdema\MofhClient\Message;
 
+/**
+ * @method AvailablityResponse send() Send the request.
+ */
 class AvailabilityRequest extends AbstractRequest
 {
     public function getDomain()

--- a/src/Message/CreateAccountRequest.php
+++ b/src/Message/CreateAccountRequest.php
@@ -2,6 +2,9 @@
 
 namespace HansAdema\MofhClient\Message;
 
+/**
+ * @method CreateAccountRequest send() Send the request.
+ */
 class CreateAccountRequest extends AbstractRequest
 {
     public function getPassword()

--- a/src/Message/GetUserDomainsRequest.php
+++ b/src/Message/GetUserDomainsRequest.php
@@ -2,6 +2,9 @@
 
 namespace HansAdema\MofhClient\Message;
 
+/**
+ * @method GetUserDomainsResponse send() Send the request.
+ */
 class GetUserDomainsRequest extends AbstractRequest
 {
     public function sendData($data)

--- a/src/Message/PasswordRequest.php
+++ b/src/Message/PasswordRequest.php
@@ -2,6 +2,9 @@
 
 namespace HansAdema\MofhClient\Message;
 
+/**
+ * @method PasswordResponse send() Send the request.
+ */
 class PasswordRequest extends AbstractRequest
 {
     public function getPassword()

--- a/src/Message/SuspendRequest.php
+++ b/src/Message/SuspendRequest.php
@@ -2,6 +2,9 @@
 
 namespace HansAdema\MofhClient\Message;
 
+/**
+ * @method SuspendResponse send() Send the request.
+ */
 class SuspendRequest extends AbstractRequest
 {
     public function getReason()

--- a/src/Message/UnsuspendRequest.php
+++ b/src/Message/UnsuspendRequest.php
@@ -2,6 +2,9 @@
 
 namespace HansAdema\MofhClient\Message;
 
+/**
+ * @method UnsuspendResponse send() Send the request.
+ */
 class UnsuspendRequest extends AbstractRequest
 {
     public function getDomain()


### PR DESCRIPTION
I've updated the phpdoc to improve autocompletion in my IDE.

Example:
For the `CreateAccountResponse`, my IDE (PhpStorm) was alerting my that the `getVpUsername()` method did not exist, which was annoying.

I've modified the `@return` values for some of the methods in client.php and indicated the `send()` method return types in the request classes.