### PR TITLE
Remove username from getCname

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ The MyOwnFreeHost API exposes the following methods. The available parameters ar
 - getDomainUser: Get the information of a particular hosting domain name, including the account it's hosted on and the document root.
     - domain: The domain name to search for.
 - getCname: Get the CNAME subdomain for a domain name, used for CNAME domain verification.
-    - username: The VistaPanel login username (e.g. abcd_12345678).
     - domain: The domain name to generate the CNAME subdomain for.
 
 ### Example

--- a/src/Client.php
+++ b/src/Client.php
@@ -262,7 +262,6 @@ class Client
         $response = $this->sendPostRequest('getcname', [
             'api_user' => $this->apiUsername,
             'api_key' => $this->apiPassword,
-            'username' => $username,
             'domain_name' => $domain,
         ]);
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -261,7 +261,6 @@ class ClientTest extends TestCase
             'api_user' => $this->apiUsername,
             'api_key' => $this->apiPassword,
             'domain_name' => $domain,
-            'username' => $username,
         ], $postData);
     }
 }


### PR DESCRIPTION
iFastNet left this in by mistake - it has now been removed. (See [#33](https://github.com/Wallvon/MOFH-API-Docs/issues/33))